### PR TITLE
Remove relPath (fix for #178)

### DIFF
--- a/util/blender_extra/material.py
+++ b/util/blender_extra/material.py
@@ -257,9 +257,8 @@ def setImage(fileName, directory, nodes, nodeName, imageSuffix=None):
             fileName = "%s_%s.png" % (fileName[:-4], imageSuffix)
         image = bpy.data.images.get(fileName if directory else os.path.basename(fileName))
         if not image:
-            imagePath = bpy.path.relpath(
-                os.path.join(directory, fileName) if directory else fileName
-            )
+            imagePath = os.path.join(directory, fileName) if directory else fileName
+            
             try:
                 image = bpy.data.images.load(imagePath)
             except Exception:


### PR DESCRIPTION
Relative path is not necessary at all. If blender.exe and the resource file are located on different drives, it fails.
Also, it's like a pain in the ass for me. Every time do this patch manually!

This fixes #178 