### PR TITLE
add custom name support for osm maps and terrain

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,15 +71,18 @@ class BaseApp:
             f.write(u.read())
         print("Saving the file to %s..." % filepath)
     
-    def downloadOsmFile(self, osmDir, minLon, minLat, maxLon, maxLat):
+    def downloadOsmFile(self, osmDir, minLon, minLat, maxLon, maxLat, customName):
         # find a file name for the OSM file
         osmFileName = BaseApp.osmFileName % ""
         counter = 1
         while True:
             osmFilepath = os.path.realpath( os.path.join(osmDir, osmFileName) )
             if os.path.isfile(osmFilepath):
-                counter += 1
-                osmFileName = BaseApp.osmFileName % "_%s" % counter
+                if customName != "":
+                    osmFileName = BaseApp.osmFileName % "_%s" % customName
+                else:
+                    counter += 1
+                    osmFileName = BaseApp.osmFileName % "_%s" % counter
             else:
                 break
         self.osmFilepath = osmFilepath

--- a/app/blender.py
+++ b/app/blender.py
@@ -112,6 +112,7 @@ class BlenderApp(BaseApp):
     
     voidValue = -32768
     voidSubstitution = 0
+    customName = ""
     
     def __init__(self):
         super().__init__()
@@ -198,7 +199,7 @@ class BlenderApp(BaseApp):
         ]
         
         if addon.osmSource == "server":
-            self.downloadOsmFile(osmDir, self.minLon, self.minLat, self.maxLon, self.maxLat)
+            self.downloadOsmFile(osmDir, self.minLon, self.minLat, self.maxLon, self.maxLat, self.customName)
         else:
             self.osmFilepath = os.path.realpath(bpy.path.abspath(self.osmFilepath))
 
@@ -531,10 +532,17 @@ class BlenderApp(BaseApp):
             v[2] -= minHeight
         
         # create a mesh object in Blender
-        mesh = bpy.data.meshes.new("Terrain")
+        if context.scene.blosm.terrainName != "Terrain":
+            mesh = bpy.data.meshes.new(context.scene.blosm.terrainName)
+        else:
+            mesh = bpy.data.meshes.new("Terrain")
         mesh.from_pydata(verts, [], indices)
         mesh.update()
-        obj = bpy.data.objects.new("Terrain", mesh)
+        if context.scene.blosm.terrainName != "Terrain":
+            obj = bpy.data.objects.new(context.scene.blosm.terrainName, mesh)
+        else:
+            obj = bpy.data.objects.new("Terrain", mesh)
+            
         obj["height_offset"] = minHeight
         context.scene.collection.objects.link(obj)
         context.scene.blosm.terrainObject = obj.name

--- a/app/command_line.py
+++ b/app/command_line.py
@@ -42,6 +42,7 @@ class CommandLineApp(BaseApp):
         argParser.add_argument("--osmFilepath", help="Path to an OSM file")
         argParser.add_argument("--osmDir", help="A directory for the downloaded OSM files")
         argParser.add_argument("--setupScript", help="The path to a custom setup script")
+        argParser.add_argument("--customName", help="A custom name for the downloaded OSM file", default="")
         
         argParser.add_argument("--buildings", action='store_true', help="Import buildings", default=False)
         argParser.add_argument("--highways", action='store_true', help="Import roads and paths", default=False)
@@ -76,7 +77,7 @@ class CommandLineApp(BaseApp):
         if self.osmFilepath:
             self.osmFilepath = os.path.realpath(self.osmFilepath)
         else:
-            self.downloadOsmFile(self.osmDir, self.minLon, self.minLat, self.maxLon, self.maxLat)
+            self.downloadOsmFile(self.osmDir, self.minLon, self.minLat, self.maxLon, self.maxLat, self.customName)
 
     def render(self):
         logger = self.logger

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -863,6 +863,12 @@ class BlosmProperties(bpy.types.PropertyGroup):
         default = 3.
     )
     
+    customName: bpy.props.StringProperty(
+        name = "Custom name",
+        description = "Custom name for the imported objects",
+        default = ""
+    )
+    
     defaultLevels: bpy.props.CollectionProperty(type = BlosmDefaultLevelsEntry)
     
     defaultLevelsIndex: bpy.props.IntProperty(
@@ -921,6 +927,12 @@ class BlosmProperties(bpy.types.PropertyGroup):
         items=(("quad","quad","quad"),("triangle","triangle","triangle")),
         description="Primitive type used for the terrain mesh: quad or triangle",
         default="quad"
+    )
+    
+    terrainName: bpy.props.StringProperty(
+        name="Terrain name",
+        description="Name for the terrain object",
+        default="Terrain"
     )
 
     # Number of vertex reduction

--- a/parse/osm/__init__.py
+++ b/parse/osm/__init__.py
@@ -77,6 +77,8 @@ class Osm:
         self.minLon = 0.
         self.maxLon = 0.
     
+        self.customName = ""
+        
     def addCondition(self, condition, layerId=None, manager=None, renderer=None):
         self.conditions.append(
             (condition, manager, renderer, layerId)

--- a/terrain/__init__.py
+++ b/terrain/__init__.py
@@ -261,9 +261,18 @@ class Terrain:
                 vertsCounter += 1
         
         # create a mesh object in Blender
-        mesh = bpy.data.meshes.new("Terrain")
+        if context.scene.blosm.terrainName != "Terrain":
+            mesh = bpy.data.meshes.new(context.scene.blosm.terrainName)
+        else:
+            mesh = bpy.data.meshes.new("Terrain")
+
         mesh.from_pydata(verts, [], indices)
         mesh.update()
-        obj = bpy.data.objects.new("Terrain", mesh)
+
+        if context.scene.blosm.terrainName != "Terrain":
+            obj = bpy.data.objects.new(context.scene.blosm.terrainName, mesh)
+        else:
+            obj = bpy.data.objects.new("Terrain", mesh)
+
         bpy.context.scene.collection.objects.link(obj)
         return obj.name


### PR DESCRIPTION
This PR adds the ability to provide custom names for terrain and osm map names. I have the following piece of code where I access map osm buildings and terrain data. 

```python
bpy.data.objects[f'Terrain.{str(index).zfill(3)}'].select_set(True)
bpy.data.objects[f'map_{index+1}.osm_buildings'].select_set(True)
```
I have parallelized this to download and access multiple different objects at the same time. My problem is now that the current implementation assigns an index to the name of the terrain and the osm map and when downloading in parallel, multiple maps end up with the same name. With this PR I can run:

```python
bpy.context.scene.blosm.customName = f'{index+1}'
bpy.context.scene.blosm.terrainName = f'Terrain.{str(index).zfill(3)}'
```
which allows me to set custom names for each map that is downloaded. 
@vvoovv Using these modifications with the code above in Python works fine; however, when i try to run this in the GUI in Blender I get an error saying: `AttributeError: type object 'Renderer' has no attribute 'toJoin'` I am not really sure why this is. Do you have an idea? I have marked the PR as a draft for now because of this. 

Note: I have only tested this on the base version of blosm so I don't know how it would perform on the premium version.